### PR TITLE
chore: Clarify types in doc

### DIFF
--- a/pages/spec-1.0/index.mdx
+++ b/pages/spec-1.0/index.mdx
@@ -2,7 +2,7 @@
 
 The Open Tool Calling (OTC) standard establishes a set of protocols and formats to facilitate communication between agents (clients) and tools (functions or services) in distributed systems. It ensures that tool definitions, requests, and responses adhere to a structured and open standard.
 
-This document defines the structures and protocols used to describe tools, initiate tool calls, and process responses. The standard consists of a set of JSON schemas that govern tool definitions, tool requests, and tool responses as described in the [OpenAPI spec](https://spec.openapis.org/registry-metadata/openapi-extensions). It aims to provide a unified, extensible, and interoperable framework for client-to-tool interactions.
+This document defines the structures and protocols used to describe tools, initiate tool calls, and process responses. The standard consists of a set of JSON schemas that govern tool definitions, tool requests, and tool responses as described in the [OTC OpenAPI spec](https://github.com/OpenToolCalling/Specification/tree/main/spec/http/1.0/openapi.json). It aims to provide a unified, extensible, and interoperable framework for client-to-tool interactions.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [BCP 14](https://datatracker.ietf.org/doc/html/bcp14) [[RFC2119](https://datatracker.ietf.org/doc/html/rfc2119)] [[RFC8174](https://datatracker.ietf.org/doc/html/rfc8174)] when, and only when, they appear in all capitals, as shown here.
 

--- a/pages/spec-1.0/schemas/call-tool-request.mdx
+++ b/pages/spec-1.0/schemas/call-tool-request.mdx
@@ -6,14 +6,14 @@ The `CallToolRequest` schema encapsulates the details of a tool call (execution 
 
 ### Run and Execution Identification
 
-- **`tool_id`**: The unique identifier of the tool to call.
-- **`call_id`** (optional): A unique identifier and idempotency key for this tool call.
+- **`tool_id`** (string, required): The unique identifier of the tool to call.
+- **`call_id`** (string, optional): A unique identifier and idempotency key for this tool call.
   If not provided, the server will generate one and return it in the response.
-- **`trace_id`** (optional): Unique trace or span identifier for tracing purposes..
+- **`trace_id`** (string, optional): Unique trace or span identifier for tracing purposes..
 
 ### Input Parameters
 
-- **`inputs`**: An unconstrained object containing the parameters needed by the tool.
+- **`inputs`** (object, required): An unconstrained object containing the parameters needed by the tool.
 
 ### Context
 
@@ -21,14 +21,14 @@ If the `requirements` field is present on a given [tool definition](tool-definit
 the client MUST provide the required information in the `context` field when calling the tool.
 See the [call tool flow](../flows/call-tool) section for more details.
 
-- **`context`** (optional): Provides additional execution context, consisting of:
-  - **`authorization`** (optional): Contains tokens for authentication, described as an array of objects with the following properties:
-    - **`id`**: The unique identifier for the authorization method or authorization provider.
-    - **`token`**: The authorization token.
-  - **`secrets`** (optional): Contains secrets for the tool call, described as an array of objects with the following properties:
-    - **`id`**: The unique identifier for the secret.
-    - **`value`**: The secret value.
-  - **`user_id`** (optional): The unique identifier for the user.
+- **`context`** (object, optional): Provides additional execution context, consisting of:
+  - **`authorization`** (array, optional): Contains tokens for authentication, described as an array of objects with the following properties:
+    - **`id`** (string): The unique identifier for the authorization method or authorization provider.
+    - **`token`** (string): The authorization token.
+  - **`secrets`** (array, optional): Contains secrets for the tool call, described as an array of objects with the following properties:
+    - **`id`** (string): The unique identifier for the secret.
+    - **`value`** (string): The secret value.
+  - **`user_id`** (string, optional): The unique identifier for the user.
 
 If the `requirements.authorization` field is present on a given tool definition, the client MUST provide the required authorization information in the `context.authorization` field when [calling the tool](../flows/call-tool).
 

--- a/pages/spec-1.0/schemas/call-tool-response.mdx
+++ b/pages/spec-1.0/schemas/call-tool-response.mdx
@@ -6,8 +6,8 @@ The `CallToolResponse` schema defines the structured data returned from a tool c
 
 ### Execution Metadata
 
-- **`call_id`** (string): A unique identifier for this call. If `call_id` is not present in the [request](call-tool-request), the server MUST generate one and return it in the response.
-- **`success`** (boolean): Boolean flag indicating the success or failure of the call.
+- **`call_id`** (string, required): A unique identifier for this call. If `call_id` is not present in the [request](call-tool-request), the server MUST generate one and return it in the response.
+- **`success`** (boolean, required): Boolean flag indicating the success or failure of the call.
 - **`duration`** (number, optional): Call time in milliseconds.
 
 ### Output Content

--- a/pages/spec-1.0/schemas/call-tool-response.mdx
+++ b/pages/spec-1.0/schemas/call-tool-response.mdx
@@ -6,9 +6,9 @@ The `CallToolResponse` schema defines the structured data returned from a tool c
 
 ### Execution Metadata
 
-- **`call_id`**: A unique identifier for this call. If `call_id` is not present in the [request](call-tool-request), the server MUST generate one and return it in the response.
-- **`success`**: Boolean flag indicating the success or failure of the call.
-- **`duration`** (optional): Call time in milliseconds.
+- **`call_id`** (string): A unique identifier for this call. If `call_id` is not present in the [request](call-tool-request), the server MUST generate one and return it in the response.
+- **`success`** (boolean): Boolean flag indicating the success or failure of the call.
+- **`duration`** (number, optional): Call time in milliseconds.
 
 ### Output Content
 
@@ -17,11 +17,11 @@ The output can take one of several forms:
 1. **Null Response**: Contains execution metadata only.
 2. **Value Response**: Contains execution metadata and a `value` field that MUST be a JSON value, array, or object conforming to the [output schema](tool-definition#output-schema) of the tool.
 3. **Error Response**: Contains execution metadata and an `error` object with:
-   - **`message`**: A user-facing error message.
-   - **`developer_message`** (optional): Detailed error information for internal debugging.
-   - **`can_retry`** (optional): Indicates if the request can be retried by the client. If unspecified, the client MUST assume the request cannot be retried (`false`).
-   - **`additional_prompt_content`** (optional): Extra content to be used for retry prompts.
-   - **`retry_after_ms`** (optional): Suggested delay before retrying.
+   - **`message`** (string): A user-facing error message.
+   - **`developer_message`** (string, optional): Detailed error information for internal debugging.
+   - **`can_retry`** (boolean, optional): Indicates if the request can be retried by the client. If unspecified, the client MUST assume the request cannot be retried (`false`).
+   - **`additional_prompt_content`** (string, optional): Extra content to be used for retry prompts.
+   - **`retry_after_ms`** (number, optional): How long to wait before retrying the call (in milliseconds).
 
 The `CallToolResponse` schema ensures that every response provides clear and actionable information regarding the outcome of the tool call, regardless of whether the tool's function or service code executed successfully or not.
 

--- a/pages/spec-1.0/schemas/tool-definition.mdx
+++ b/pages/spec-1.0/schemas/tool-definition.mdx
@@ -6,16 +6,16 @@ The `ToolDefinition` schema establishes the required and optional fields to desc
 
 ### Metadata
 
-- **`id`** (required): A unique identifier for the tool, in the following format: `ToolkitName.ToolName@Version`. For example, `Calculator.Add@1.0.0`. The `id` MUST be unique within the scope of the Tool Server.
-- **`name`** (required): A human-readable name for the tool. For example, `Add` or `Calculator_Add`. The name MUST contain only alphanumeric characters, underscores, and dashes, and be between 1 and 64 characters in length.
-- **`description`** (required): A human-readable explanation of the tool's purpose. This field SHOULD be used by both humans and AI models.
-- **`version`** (required): The semantic version of the tool, e.g. `1.0.0`. Multiple versions of the same tool MAY exist.
+- **`id`** (string, required): A unique identifier for the tool, in the following format: `ToolkitName.ToolName@Version`. For example, `Calculator.Add@1.0.0`. The `id` MUST be unique within the scope of the Tool Server.
+- **`name`** (string, required): A human-readable name for the tool. For example, `Add` or `Calculator_Add`. The name MUST contain only alphanumeric characters, underscores, and dashes, and be between 1 and 64 characters in length.
+- **`description`** (string, required): A human-readable explanation of the tool's purpose. This field SHOULD be used by both humans and AI models.
+- **`version`** (string, required): The semantic version of the tool, e.g. `1.0.0`. Multiple versions of the same tool MAY exist.
 
 Tools MUST be versioned using simple semantic versioning of the form `x.y.z` where `x`, `y`, and `z` are integers.
 
 ### Input Schema
 
-- **`input_schema`** (required): Describes the input parameters for the tool.
+- **`input_schema`** (required): Describes the input parameters for the tool. An object with the following properties:
 
   - **`parameters`** (required): A JSON Schema object that describes the input parameters for the tool.
     This schema supports standard JSON Schema validation, but excludes `$ref` and nested definitions/schemas for simplicity.
@@ -30,20 +30,20 @@ The `parameters` field MUST be present, and MAY be an empty object. Each paramet
 
 ### Requirements
 
-- **`requirements`** (optional): Describes tool requirements that are not strictly input parameters, such as an API key needed to call a target API, or that a tool requires OAuth 2.0-based authorization.
+- **`requirements`** (optional): Describes tool requirements that are not strictly input parameters, such as an API key needed to call a target API, or that a tool requires OAuth 2.0-based authorization. The object MAY contain the following fields:
 
-  - **`authorization`** (optional): Declares one or more required authorization methods, described as an array of objects with the following properties:
+  - **`authorization`** (array, optional): Declares one or more required authorization methods, described as an array of objects with the following properties:
 
-    - **`id`**: A unique identifier for the authorization method or authorization provider.
+    - **`id`** (string): A unique identifier for the authorization method or authorization provider.
     - **`oauth2`** (optional): For tools that need OAuth 2.0-based authorization, this field contains the OAuth 2.0-specific authorization details.
 
-      - **`scopes`**: A list of scopes that must be granted for the tool to execute properly.
+      - **`scopes`** (array of strings): A list of scopes that must be granted for the tool to execute properly.
 
-  - **`secrets`** (optional): Declares one or more secrets, described as an array of objects with the following properties:
+  - **`secrets`** (array, optional): Declares one or more secrets, described as an array of objects with the following properties:
 
-    - **`id`**: A unique identifier for the secret.
+    - **`id`** (string): A unique identifier for the secret.
 
-  - **`user_id`** (optional): A unique identifier for the user, for tools that need user identification or user-based authorization.
+  - **`user_id`** (boolean, optional): `true` if the tool requires a user ID, `false` (or omitted) otherwise.
 
 ## Non-Normative Examples
 


### PR DESCRIPTION
Fix another link and clarifies schema types in the spec doc.